### PR TITLE
Support API Token for Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Put them in your `.env` as the following, obviously and respectively.
 
 1. `CLOUDFLARE_EMAIL`
 2. `CLOUDFLARE_API_KEY`
-3. `CLOUDFLARE_ZONE_ID`
+3. `CLOUDFLARE_API_TOKEN`, the preferred way. [Create a token](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/). 
+4. `CLOUDFLARE_ZONE_ID`
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Get the following information.
 
 Put them in your `.env` as the following, obviously and respectively.
 
-1. `CLOUDFLARE_EMAIL`
-2. `CLOUDFLARE_API_KEY`
-3. `CLOUDFLARE_API_TOKEN`, the preferred way. [Create a token](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/). 
-4. `CLOUDFLARE_ZONE_ID`
+1. `CLOUDFLARE_EMAIL`, the legacy way, must be provided with `CLOUDFLARE_API_KEY`.
+2. `CLOUDFLARE_API_KEY`, the legacy way, must be provided with `CLOUDFLARE_EMAIL`.
+3. `CLOUDFLARE_API_TOKEN`, the preferred way, no email or key required. [Create a token](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/).
+4. `CLOUDFLARE_ZONE_ID`, optional.
 
 ## How to use
 

--- a/config/cloudflare.php
+++ b/config/cloudflare.php
@@ -7,9 +7,13 @@ return [
     'email' => env('CLOUDFLARE_EMAIL'),
 
     /*
-     * Your Cloudflare API Key
+     * Your Cloudflare API (Global) Key to pair with email
      */
     'key' => env('CLOUDFLARE_API_KEY'),
+
+    /*
+     * Your API Token, the preferable way
+    'token' => env('CLOUDFLARE_TOKEN'),
 
     /*
      * The Zone you would like to modify

--- a/config/cloudflare.php
+++ b/config/cloudflare.php
@@ -13,6 +13,7 @@ return [
 
     /*
      * Your API Token, the preferable way
+     */
     'token' => env('CLOUDFLARE_TOKEN'),
 
     /*

--- a/config/cloudflare.php
+++ b/config/cloudflare.php
@@ -14,7 +14,7 @@ return [
     /*
      * Your API Token, the preferable way
      */
-    'token' => env('CLOUDFLARE_TOKEN'),
+    'token' => env('CLOUDFLARE_API_TOKEN'),
 
     /*
      * The Zone you would like to modify

--- a/src/Cloudflare.php
+++ b/src/Cloudflare.php
@@ -67,9 +67,9 @@ class Cloudflare
     protected ZoneSubscriptions $zoneSubscriptions;
     protected Zones $zones;
 
-    public function __construct($email, $api, $token, $zoneId = null)
+    public function __construct($email, $api, $token = null, $zoneId = null)
     {
-        $auth = $this->getAuth($token, $email, $api);
+        $auth = $this->getAuth($email, $api, $token);
         if (empty($auth)) {
             // Ideally it throws exception, but for now, it silently stops.
             return;
@@ -255,7 +255,7 @@ class Cloudflare
      *
      * When possible, use API tokens instead of Global API keys.
      */
-    private function getAuth($token, $email, $api): ?Auth
+    private function getAuth($email, $api, $token): ?Auth
     {
         if (!empty($token)) {
             return new Token($token);

--- a/src/Cloudflare.php
+++ b/src/Cloudflare.php
@@ -2,7 +2,9 @@
 
 namespace Joshuapack\Cloudflare;
 
+use Cloudflare\API\Auth\Auth;
 use Cloudflare\API\Auth\APIKey as Key;
+use Cloudflare\API\Auth\APIToken as Token;
 use Illuminate\Support\Traits\Macroable;
 use GuzzleHttp\Exception\ClientException;
 use Cloudflare\API\Endpoints\AccessRules;
@@ -65,14 +67,15 @@ class Cloudflare
     protected ZoneSubscriptions $zoneSubscriptions;
     protected Zones $zones;
 
-    public function __construct($email, $api, $zoneId = null)
+    public function __construct($email, $api, $token, $zoneId = null)
     {
-        if (!is_string($email) || !is_string($api)) {
+        $auth = $this->getAuth($token, $email, $api);
+        if (empty($auth)) {
+            // Ideally it throws exception, but for now, it silently stops.
             return;
         }
 
-        $key = new Key($email, $api);
-        $adapter = new Adapter($key);
+        $adapter = new Adapter($auth);
         $this->zoneId = $zoneId;
         $this->accessRules = new AccessRules($adapter);
         $this->accountMembers = new AccountMembers($adapter);
@@ -242,4 +245,26 @@ class Cloudflare
         }
     }
 
+    /**
+     * Create authentication using API token or email and key combination.
+     *
+     * The preferred authorization scheme for interacting with the Cloudflare API is using token.
+     * Check on how to create token here: https://developers.cloudflare.com/fundamentals/api/get-started/create-token/
+     * 
+     * The previous authorization scheme for interacting with the Cloudflare API is using email in conjunction with a Global API key.
+     *
+     * When possible, use API tokens instead of Global API keys.
+     */
+    private function getAuth($token, $email, $api): ?Auth
+    {
+        if (!empty($token)) {
+            return new Token($token);
+        }
+        
+        if (!empty($email) && !empty($api)) {
+            return new Key($email, $api);
+        }
+
+        return null;
+    }
 }

--- a/src/CloudflareServiceProvider.php
+++ b/src/CloudflareServiceProvider.php
@@ -27,7 +27,7 @@ class CloudflareServiceProvider extends ServiceProvider
             if (!$zone || $zone == '') {
                 $zone = null;
             }
-            return new Cloudflare($cloudflareConfig['email'], $cloudflareConfig['key'], $zone);
+            return new Cloudflare($cloudflareConfig['email'], $cloudflareConfig['key'], $cloudflareConfig['token'], $zone);
         });
 
         $this->app->alias(Cloudflare::class, 'laravel-cloudflare');

--- a/src/CloudflareServiceProvider.php
+++ b/src/CloudflareServiceProvider.php
@@ -27,7 +27,10 @@ class CloudflareServiceProvider extends ServiceProvider
             if (!$zone || $zone == '') {
                 $zone = null;
             }
-            return new Cloudflare($cloudflareConfig['email'], $cloudflareConfig['key'], $cloudflareConfig['token'], $zone);
+
+            $token = $cloudflareConfig['token'] ?? null;
+            
+            return new Cloudflare($cloudflareConfig['email'], $cloudflareConfig['key'], $token, $zone);
         });
 
         $this->app->alias(Cloudflare::class, 'laravel-cloudflare');


### PR DESCRIPTION
Cloudflare prefers interacting with the Cloudflare API using API Token instead of using Email+Key.

To create API Token, check: https://developers.cloudflare.com/fundamentals/api/get-started/create-token/

This PR adds support for API Token. If the API Token is provided in the config, it will use the API token. Otherwise, it fallback to Email and Key for the authentication.